### PR TITLE
fix: AWS Secrets Manager統合とCDKドキュメント改善

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -557,6 +557,39 @@ tokio::spawn(async move {
    - ブラウザの開発者ツール > Network タブ
    - リクエスト/レスポンスのペイロード確認
 
+## ⚠️ AWS CDKデプロイ時の必須事項 / Critical Requirements for AWS CDK Deployment
+
+### ドメイン環境変数の設定が必須 / Domain Environment Variables are REQUIRED
+
+**問題**: ドメイン環境変数が設定されていない場合、以下の深刻な問題が発生します：
+
+1. ALBStackがHTTPSリスナーを作成しない
+2. ECSServiceStackがHTTPSリスナーを参照しようとして失敗
+3. 両スタックが相互依存でUPDATE_ROLLBACK_COMPLETE状態になる
+4. MonitoringStackなど依存スタックもデプロイできなくなる
+
+**解決策**: CDKデプロイ前に必ず環境変数を設定
+
+```bash
+# 開発環境の場合
+export DEV_DOMAIN=dev.markmail.engineers-hub.ltd
+
+# ステージング環境の場合
+export STAGING_DOMAIN=staging.markmail.engineers-hub.ltd
+
+# 本番環境の場合
+export PROD_DOMAIN=markmail.engineers-hub.ltd
+
+# デプロイコマンド実行
+npm run cdk -- deploy StackName --profile your-profile
+```
+
+**絶対にやってはいけないこと**:
+
+- ❌ 環境変数なしでCDKデプロイを実行
+- ❌ AWS CLIで手動でリソースを作成・修正
+- ❌ スタック間の依存関係を無視した操作
+
 ## 🔧 AWS RDS操作方法 / How to Operate AWS RDS
 
 ### RDSへの接続方法 / How to Connect to RDS
@@ -723,6 +756,82 @@ aws secretsmanager get-secret-value \
 - **使用後は削除を検討** / Consider deletion after use
 - **本番環境では特に慎重に操作** / Be extra careful in production
 - **データベースのバックアップを確認** / Verify database backups exist
+
+## 🔐 AWS Secrets Manager でのAI API キー管理 / Managing AI API Keys with AWS Secrets Manager
+
+### AI用シークレットの初期設定 / Initial Setup for AI Secrets
+
+AWS環境では、AI関連のAPIキー（OPENAI_API_KEY、ANTHROPIC_API_KEY等）はSecrets
+Managerで管理されます。
+
+#### 1. シークレットの更新 / Update Secrets
+
+```bash
+# シークレットの内容を更新 / Update secret values
+aws secretsmanager update-secret \
+  --secret-id markmail-dev-ai-secret \
+  --secret-string '{
+    "OPENAI_API_KEY": "sk-xxxxxxxxxxxxxxxxxxxxxxxx",
+    "ANTHROPIC_API_KEY": "sk-ant-xxxxxxxxxxxxxxxx",
+    "AI_PROVIDER": "openai",
+    "OPENAI_MODEL": "gpt-4",
+    "ANTHROPIC_MODEL": "claude-3-opus-20240229"
+  }' \
+  --profile your-profile
+```
+
+#### 2. シークレットの確認 / Verify Secrets
+
+```bash
+# 現在の値を確認（注意：実際のAPIキーが表示されます） / Verify current values (WARNING: displays actual API keys)
+aws secretsmanager get-secret-value \
+  --secret-id markmail-dev-ai-secret \
+  --query 'SecretString' \
+  --output text \
+  --profile your-profile | jq '.'
+```
+
+#### 3. ECSサービスの再デプロイ / Redeploy ECS Service
+
+シークレットを更新した後は、ECSサービスを再デプロイして新しい値を反映させます：
+
+```bash
+# バックエンドサービスを強制的に再デプロイ / Force redeploy backend service
+aws ecs update-service \
+  --cluster markmail-dev \
+  --service markmail-dev-backend \
+  --force-new-deployment \
+  --profile your-profile
+```
+
+#### 4. シークレットのローテーション / Secret Rotation
+
+定期的にAPIキーをローテーションすることを推奨します：
+
+```bash
+# 新しいAPIキーでシークレットを更新 / Update secret with new API key
+aws secretsmanager update-secret \
+  --secret-id markmail-dev-ai-secret \
+  --secret-string '{
+    "OPENAI_API_KEY": "sk-new-key-xxxxxxxxxxxxxxxx",
+    "ANTHROPIC_API_KEY": "sk-ant-new-key-xxxxxxxxx",
+    "AI_PROVIDER": "openai",
+    "OPENAI_MODEL": "gpt-4",
+    "ANTHROPIC_MODEL": "claude-3-opus-20240229"
+  }' \
+  --profile your-profile
+```
+
+### 注意事項 / Important Notes
+
+- **環境ごとにシークレットは分離** / Secrets are separated by environment (dev,
+  staging, prod)
+- **シークレット名の規則** / Secret naming convention:
+  `markmail-{environment}-ai-secret`
+- **ECSタスクは自動的に最新のシークレットを取得** / ECS tasks automatically
+  fetch the latest secrets
+- **ローカル開発では`.env`ファイルを使用** / Use `.env` file for local
+  development
 
 ## 🔧 トラブルシューティング
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -132,10 +132,17 @@ export GITHUB_OWNER=your-github-username
 export GITHUB_REPO=markmail
 export GITHUB_BRANCH=main
 
+# ⚠️ 重要: ドメインが設定されている環境では必須
+export DEV_DOMAIN=dev.markmail.example.com    # 開発環境のドメイン
+export STAGING_DOMAIN=staging.markmail.example.com  # ステージング環境のドメイン
+export PROD_DOMAIN=markmail.example.com      # 本番環境のドメイン
+
 # オプション（デフォルト値あり）
 export AWS_ACCOUNT_ID=123456789012
 export AWS_REGION=ap-northeast-1
 ```
+
+⚠️ **重要**: ドメイン環境変数を設定しないと、ALBがHTTPSリスナーを作成せず、ECSServiceStackのデプロイが失敗します。
 
 ### 3. CDKのブートストラップ（初回のみ）
 
@@ -290,19 +297,30 @@ npm run deploy:cicd
 
 ### デプロイが失敗する場合
 
-1. **IAM権限の確認**
+1. **環境変数の確認（最重要）**
+
+   ```bash
+   # ドメイン設定の確認
+   echo $DEV_DOMAIN
+   echo $STAGING_DOMAIN
+   echo $PROD_DOMAIN
+   ```
+
+   ⚠️ **ドメイン環境変数が未設定の場合、ALBStackとECSServiceStackで依存関係エラーが発生します**
+
+2. **IAM権限の確認**
 
    ```bash
    aws sts get-caller-identity
    ```
 
-2. **Docker daemon の確認**
+3. **Docker daemon の確認**
 
    ```bash
    docker info
    ```
 
-3. **スタック状態の確認**
+4. **スタック状態の確認**
    ```bash
    aws cloudformation describe-stacks --stack-name MarkMail-dev-*
    ```
@@ -324,6 +342,8 @@ aws logs tail /aws/codebuild/markmail-build --follow
 | `Stack is in ROLLBACK_COMPLETE state` | 前回のデプロイ失敗 | スタックを削除して再作成     |
 | `Resource limit exceeded`             | リソース制限       | Service Quotasで上限緩和申請 |
 | `Access Denied`                       | IAM権限不足        | 必要な権限を追加             |
+| `Cannot delete export...in use by`    | スタック間の依存   | 依存スタックを先に削除       |
+| `No export named...found`             | 環境変数未設定     | DEV_DOMAIN等を設定して再実行 |
 
 ## 📚 参考資料
 

--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -141,6 +141,7 @@ const ecsServiceStack = new ECSServiceStack(app, `MarkMail-${environmentName}-EC
   frontendRepo: ecrStack.frontendRepo,
   database: databaseStack.database,
   dbSecret: databaseStack.dbSecret,
+  aiSecret: databaseStack.aiSecret,
   cacheCluster: databaseStack.cacheCluster,
   loadBalancer: albStack.loadBalancer,
   httpsListener: albStack.httpsListener,

--- a/infrastructure/lib/stacks/alb-stack.ts
+++ b/infrastructure/lib/stacks/alb-stack.ts
@@ -16,7 +16,7 @@ export interface ALBStackProps extends cdk.StackProps {
 
 export class ALBStack extends cdk.Stack {
   public readonly loadBalancer: elbv2.ApplicationLoadBalancer;
-  public readonly httpsListener: elbv2.ApplicationListener;
+  public readonly httpsListener?: elbv2.ApplicationListener;
   public readonly httpListener: elbv2.ApplicationListener;
   public readonly albSecurityGroup: ec2.SecurityGroup;
 

--- a/infrastructure/lib/stacks/database-stack.ts
+++ b/infrastructure/lib/stacks/database-stack.ts
@@ -15,6 +15,7 @@ export class DatabaseStack extends cdk.Stack {
   public readonly database: cdk.aws_rds.DatabaseInstance;
   public readonly dbSecret: cdk.aws_secretsmanager.Secret;
   public readonly cacheCluster: cdk.aws_elasticache.CfnCacheCluster;
+  public readonly aiSecret: cdk.aws_secretsmanager.Secret;
 
   constructor(scope: Construct, id: string, props: DatabaseStackProps) {
     super(scope, id, props);
@@ -42,6 +43,19 @@ export class DatabaseStack extends cdk.Stack {
     this.dbSecret = database.dbSecret;
     this.cacheCluster = database.cacheCluster;
 
+    // AI関連のシークレット（OPENAI_API_KEY、ANTHROPIC_API_KEY等）
+    this.aiSecret = new cdk.aws_secretsmanager.Secret(this, 'AISecret', {
+      secretName: `markmail-${environmentName}-ai-secret`,
+      description: 'AI provider API keys (OpenAI, Anthropic)',
+      secretObjectValue: {
+        OPENAI_API_KEY: cdk.SecretValue.unsafePlainText('your-openai-api-key-here'),
+        ANTHROPIC_API_KEY: cdk.SecretValue.unsafePlainText('your-anthropic-api-key-here'),
+        AI_PROVIDER: cdk.SecretValue.unsafePlainText('openai'),
+        OPENAI_MODEL: cdk.SecretValue.unsafePlainText('gpt-4'),
+        ANTHROPIC_MODEL: cdk.SecretValue.unsafePlainText('claude-3-opus-20240229'),
+      },
+    });
+
     // Export values for cross-stack references
     new cdk.CfnOutput(this, 'DatabaseEndpoint', {
       value: this.database.dbInstanceEndpointAddress,
@@ -61,6 +75,11 @@ export class DatabaseStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'CachePort', {
       value: this.cacheCluster.attrRedisEndpointPort,
       exportName: `${this.stackName}-CachePort`,
+    });
+
+    new cdk.CfnOutput(this, 'AISecretArn', {
+      value: this.aiSecret.secretArn,
+      exportName: `${this.stackName}-AISecretArn`,
     });
 
     // Stack tags

--- a/infrastructure/lib/stacks/ecs-service-stack.ts
+++ b/infrastructure/lib/stacks/ecs-service-stack.ts
@@ -22,6 +22,7 @@ export interface ECSServiceStackProps extends cdk.StackProps {
   frontendRepo: ecr.Repository;
   database: rds.DatabaseInstance;
   dbSecret: secretsmanager.Secret;
+  aiSecret?: secretsmanager.Secret;
   cacheCluster: elasticache.CfnCacheCluster;
   loadBalancer: elbv2.ApplicationLoadBalancer;
   httpsListener?: elbv2.ApplicationListener;
@@ -56,6 +57,7 @@ export class ECSServiceStack extends cdk.Stack {
       frontendRepo,
       database,
       dbSecret,
+      aiSecret,
       cacheCluster,
       httpsListener,
       httpListener,
@@ -90,6 +92,13 @@ export class ECSServiceStack extends cdk.Stack {
       },
       secrets: {
         JWT_SECRET: ecs.Secret.fromSecretsManager(dbSecret, 'password'),
+        ...(aiSecret && {
+          OPENAI_API_KEY: ecs.Secret.fromSecretsManager(aiSecret, 'OPENAI_API_KEY'),
+          ANTHROPIC_API_KEY: ecs.Secret.fromSecretsManager(aiSecret, 'ANTHROPIC_API_KEY'),
+          AI_PROVIDER: ecs.Secret.fromSecretsManager(aiSecret, 'AI_PROVIDER'),
+          OPENAI_MODEL: ecs.Secret.fromSecretsManager(aiSecret, 'OPENAI_MODEL'),
+          ANTHROPIC_MODEL: ecs.Secret.fromSecretsManager(aiSecret, 'ANTHROPIC_MODEL'),
+        }),
       },
       logging: ecs.LogDrivers.awsLogs({
         streamPrefix: 'backend',


### PR DESCRIPTION
## 概要
AWS Secrets ManagerでAI APIキーを管理する機能を追加し、CDKデプロイ時の環境変数設定に関する重要なドキュメントを更新しました。

## 変更内容

### 🔧 機能追加
- **AWS Secrets Manager統合**
  - `DatabaseStack`に`aiSecret`リソースを追加
  - `ECSServiceStack`でSecrets Managerから環境変数を自動取得
  - AI関連のAPIキー（OPENAI_API_KEY、ANTHROPIC_API_KEY等）を安全に管理

### 🐛 修正
- `ALBStack`の`httpsListener`プロパティをオプショナルに変更
- `infrastructure.ts`でDatabaseStackのaiSecretをECSServiceStackに渡すように修正

### 📚 ドキュメント改善
- **infrastructure/README.md**
  - ドメイン環境変数（DEV_DOMAIN等）の設定を必須項目として明記
  - トラブルシューティングセクションに環境変数確認手順を追加
  - 一般的なエラーと対処法にスタック間依存エラーを追加

- **CLAUDE.md**
  - AWS CDKデプロイ時の必須事項セクションを新規追加
  - ドメイン環境変数未設定時の問題と解決策を詳細に記載
  - AWS Secrets Managerでの AI APIキー管理手順を追加

## 背景
環境変数`DEV_DOMAIN`が未設定の状態でCDKデプロイを実行すると、ALBStackがHTTPSリスナーを作成せず、ECSServiceStackがHTTPSリスナーを参照しようとして失敗し、両スタックが相互依存でUPDATE_ROLLBACK_COMPLETE状態になる深刻な問題が発生していました。

## テスト
- ✅ Backend: 76 passed; 0 failed
- ✅ Frontend: 58 passed; 0 failed
- ✅ Infrastructure: CDKコードのビルド成功

## 影響範囲
- インフラストラクチャのデプロイプロセス
- AI機能の環境変数管理方法

## 今後の対応
このPRにより、同じ問題が再発しないよう適切にドキュメント化されました。新しくプロジェクトに参加するメンバーも、ドキュメントを参照することで正しくデプロイできます。