### PR TITLE
feat: AI機能の多言語対応を実装

### DIFF
--- a/backend/src/ai/models/ai_responses.rs
+++ b/backend/src/ai/models/ai_responses.rs
@@ -8,13 +8,15 @@ pub struct GenerateContentRequest {
     pub options: Option<GenerationOptions>,
 }
 
+use crate::ai::models::Language;
+
 /// コンテンツコンテキスト
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContentContext {
     pub industry: Option<String>,
     pub target_audience: Option<String>,
     pub tone: Option<ContentTone>,
-    pub language: Option<String>,
+    pub language: Option<Language>,
     pub existing_content: Option<String>,
 }
 
@@ -62,6 +64,7 @@ pub struct OptimizeSubjectRequest {
     pub target_audience: String,
     pub campaign_goal: Option<String>,
     pub variations_count: Option<u8>,
+    pub language: Option<Language>,
 }
 
 /// 件名最適化レスポンス

--- a/backend/src/ai/models/mod.rs
+++ b/backend/src/ai/models/mod.rs
@@ -1,9 +1,42 @@
 pub mod ai_responses;
 pub mod prompts;
 
+#[cfg(test)]
+mod tests;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+/// サポートされる言語
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Language {
+    #[serde(rename = "ja")]
+    #[default]
+    Japanese,
+    #[serde(rename = "en")]
+    English,
+}
+
+impl Language {
+    /// 言語コードから変換
+    pub fn from_code(code: &str) -> Option<Self> {
+        match code.to_lowercase().as_str() {
+            "ja" | "japanese" => Some(Language::Japanese),
+            "en" | "english" => Some(Language::English),
+            _ => None,
+        }
+    }
+
+    /// 言語コードに変換
+    pub fn to_code(&self) -> &'static str {
+        match self {
+            Language::Japanese => "ja",
+            Language::English => "en",
+        }
+    }
+}
 
 /// AI生成コンテンツ
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -48,6 +81,7 @@ pub struct GenerateScenarioRequest {
     pub target_audience: String,
     pub goal: String,
     pub additional_context: Option<String>,
+    pub language: Option<Language>,
 }
 
 /// シナリオ生成レスポンス

--- a/backend/src/ai/models/prompts.rs
+++ b/backend/src/ai/models/prompts.rs
@@ -1,7 +1,12 @@
 //! プロンプトテンプレート管理
 
-/// シナリオ生成用のシステムプロンプト
-pub const SCENARIO_GENERATION_SYSTEM_PROMPT: &str = r#"
+use crate::ai::models::Language;
+
+#[cfg(test)]
+mod tests;
+
+/// シナリオ生成用のシステムプロンプト（英語）
+pub const SCENARIO_GENERATION_SYSTEM_PROMPT_EN: &str = r#"
 You are an experienced marketing strategist. Design a complete marketing funnel based on the given industry, target audience, and goal.
 
 You must respond with valid JSON only. Do not include any explanatory text before or after the JSON.
@@ -59,28 +64,113 @@ Example template_index usage:
 Example variables: {{first_name}}, {{company_name}}, {{email}}
 "#;
 
+/// シナリオ生成用のシステムプロンプト（日本語）
+pub const SCENARIO_GENERATION_SYSTEM_PROMPT_JA: &str = r#"
+あなたは経験豊富なマーケティング戦略家です。指定された業界、ターゲット層、目標に基づいて、完全なマーケティングファネルを設計してください。
+
+必ず有効なJSONのみで応答してください。JSONの前後に説明文を含めないでください。
+
+応答は以下の構造に正確に従ってください：
+{
+  "scenario_name": "文字列",
+  "description": "文字列", 
+  "sequence": {
+    "name": "文字列",
+    "description": "文字列",
+    "trigger_type": "manual",
+    "steps": [
+      {
+        "name": "文字列",
+        "step_type": "email",
+        "delay_value": 数値,
+        "delay_unit": "minutes",
+        "template_index": 数値（templatesベクトルへの0ベースのインデックス）,
+        "conditions": null
+      }
+    ]
+  },
+  "forms": [
+    {
+      "name": "文字列",
+      "description": "文字列", 
+      "fields": [
+        {
+          "field_type": "text|email|select|checkbox|radio|textarea",
+          "name": "文字列",
+          "label": "文字列",
+          "required": 真偽値,
+          "options": null または ["文字列"]
+        }
+      ]
+    }
+  ],
+  "templates": [
+    {
+      "name": "文字列",
+      "subject": "文字列",
+      "content": "文字列（マークダウンを使用）",
+      "variables": ["文字列"]
+    }
+  ]
+}
+
+適切な遅延を設定した5-10のメールステップを含めてください。パーソナライゼーション変数には{{変数名}}を使用してください。
+
+template_indexの使用例：
+- templatesベクトルに3つのテンプレートがある場合、template_index: 0、1、または2を使用
+- 各ステップはインデックスを介してテンプレートを参照する必要があります
+
+変数の例：{{first_name}}、{{company_name}}、{{email}}
+"#;
+
+/// 言語に応じてシナリオ生成プロンプトを取得
+pub fn get_scenario_system_prompt(language: &Language) -> &'static str {
+    match language {
+        Language::Japanese => SCENARIO_GENERATION_SYSTEM_PROMPT_JA,
+        Language::English => SCENARIO_GENERATION_SYSTEM_PROMPT_EN,
+    }
+}
+
 /// シナリオ生成用のユーザープロンプトテンプレート
 pub fn generate_scenario_user_prompt(
     industry: &str,
     target: &str,
     goal: &str,
     context: Option<&str>,
+    language: &Language,
 ) -> String {
-    let mut prompt = format!(
-        "Industry: {}\nTarget Audience: {}\nGoal: {}\n",
-        industry, target, goal
-    );
+    match language {
+        Language::Japanese => {
+            let mut prompt = format!(
+                "業界: {}\nターゲット層: {}\n目標: {}\n",
+                industry, target, goal
+            );
 
-    if let Some(ctx) = context {
-        prompt.push_str(&format!("\nAdditional Context: {}", ctx));
+            if let Some(ctx) = context {
+                prompt.push_str(&format!("\n追加の文脈: {}", ctx));
+            }
+
+            prompt.push_str("\n\n上記の情報に基づいて、効果的なマーケティングシナリオを生成してください。必ず有効なJSONのみで応答してください。");
+            prompt
+        }
+        Language::English => {
+            let mut prompt = format!(
+                "Industry: {}\nTarget Audience: {}\nGoal: {}\n",
+                industry, target, goal
+            );
+
+            if let Some(ctx) = context {
+                prompt.push_str(&format!("\nAdditional Context: {}", ctx));
+            }
+
+            prompt.push_str("\n\nGenerate an effective marketing scenario based on the above information. Remember to respond with valid JSON only.");
+            prompt
+        }
     }
-
-    prompt.push_str("\n\nGenerate an effective marketing scenario based on the above information. Remember to respond with valid JSON only.");
-    prompt
 }
 
-/// コンテンツ生成用のシステムプロンプト
-pub const CONTENT_GENERATION_SYSTEM_PROMPT: &str = r#"
+/// コンテンツ生成用のシステムプロンプト（日本語）
+pub const CONTENT_GENERATION_SYSTEM_PROMPT_JA: &str = r#"
 あなたは優秀なコピーライターです。
 マーケティングメールのコンテンツを作成する際は、以下の点に注意してください：
 
@@ -93,13 +183,46 @@ pub const CONTENT_GENERATION_SYSTEM_PROMPT: &str = r#"
 マークダウン形式で、変数は{{variable_name}}の形式で記述してください。
 "#;
 
+/// コンテンツ生成用のシステムプロンプト（英語）
+pub const CONTENT_GENERATION_SYSTEM_PROMPT_EN: &str = r#"
+You are an excellent copywriter.
+When creating marketing email content, please pay attention to the following points:
+
+1. Subject lines that grab readers' attention
+2. Personalized greetings
+3. Clear value propositions
+4. Action-driving CTAs (Call to Action)
+5. Appropriate tone and style
+
+Write in markdown format, and use {{variable_name}} format for variables.
+"#;
+
+/// 言語に応じてコンテンツ生成プロンプトを取得
+pub fn get_content_generation_system_prompt(language: &Language) -> &'static str {
+    match language {
+        Language::Japanese => CONTENT_GENERATION_SYSTEM_PROMPT_JA,
+        Language::English => CONTENT_GENERATION_SYSTEM_PROMPT_EN,
+    }
+}
+
 /// 件名最適化用のプロンプト
 pub fn generate_subject_optimization_prompt(
     original_subject: &str,
     target_audience: &str,
+    language: &Language,
 ) -> String {
-    format!(
-        "以下の件名を、{}向けに最適化してください。開封率を高めるための5つのバリエーションを提案してください。\n\n元の件名: {}",
-        target_audience, original_subject
-    )
+    match language {
+        Language::Japanese => {
+            format!(
+                "以下の件名を、{}向けに最適化してください。開封率を高めるための5つのバリエーションを提案してください。\n\n元の件名: {}",
+                target_audience, original_subject
+            )
+        }
+        Language::English => {
+            format!(
+                "Please optimize the following subject line for {}. Suggest 5 variations to increase open rates.\n\nOriginal subject: {}",
+                target_audience, original_subject
+            )
+        }
+    }
 }

--- a/backend/src/ai/models/prompts.rs
+++ b/backend/src/ai/models/prompts.rs
@@ -68,6 +68,8 @@ Example variables: {{first_name}}, {{company_name}}, {{email}}
 pub const SCENARIO_GENERATION_SYSTEM_PROMPT_JA: &str = r#"
 あなたは経験豊富なマーケティング戦略家です。指定された業界、ターゲット層、目標に基づいて、完全なマーケティングファネルを設計してください。
 
+重要：すべての出力（scenario_name、description、メールの件名、本文など）を必ず日本語で生成してください。
+
 必ず有効なJSONのみで応答してください。JSONの前後に説明文を含めないでください。
 
 応答は以下の構造に正確に従ってください：
@@ -121,6 +123,12 @@ template_indexの使用例：
 - 各ステップはインデックスを介してテンプレートを参照する必要があります
 
 変数の例：{{first_name}}、{{company_name}}、{{email}}
+
+生成例：
+- scenario_name: "シニア向け健康イベントプロモーション"
+- description: "60歳以上のシニア層に向けた健康イベントの参加者を増やすためのマーケティングファネル"
+- メールの件名: "【無料】健康セミナーのご案内"
+- メールの本文: "{{first_name}}様、こんにちは。..."
 "#;
 
 /// 言語に応じてシナリオ生成プロンプトを取得
@@ -150,7 +158,7 @@ pub fn generate_scenario_user_prompt(
                 prompt.push_str(&format!("\n追加の文脈: {}", ctx));
             }
 
-            prompt.push_str("\n\n上記の情報に基づいて、効果的なマーケティングシナリオを生成してください。必ず有効なJSONのみで応答してください。");
+            prompt.push_str("\n\n上記の情報に基づいて、効果的なマーケティングシナリオを生成してください。すべての出力を日本語で記述し、必ず有効なJSONのみで応答してください。");
             prompt
         }
         Language::English => {
@@ -179,6 +187,8 @@ pub const CONTENT_GENERATION_SYSTEM_PROMPT_JA: &str = r#"
 3. 明確な価値提案
 4. 行動を促すCTA（Call to Action）
 5. 適切なトーンとスタイル
+
+重要：すべてのコンテンツを日本語で生成してください。
 
 マークダウン形式で、変数は{{variable_name}}の形式で記述してください。
 "#;
@@ -214,7 +224,7 @@ pub fn generate_subject_optimization_prompt(
     match language {
         Language::Japanese => {
             format!(
-                "以下の件名を、{}向けに最適化してください。開封率を高めるための5つのバリエーションを提案してください。\n\n元の件名: {}",
+                "以下の件名を、{}向けに最適化してください。開封率を高めるための5つのバリエーションを提案してください。すべての提案を日本語で記述してください。\n\n元の件名: {}",
                 target_audience, original_subject
             )
         }

--- a/backend/src/ai/models/prompts/tests.rs
+++ b/backend/src/ai/models/prompts/tests.rs
@@ -1,0 +1,73 @@
+#[cfg(test)]
+mod tests {
+    use super::super::*;
+    use crate::ai::models::Language;
+
+    #[test]
+    fn test_get_scenario_system_prompt() {
+        let ja_prompt = get_scenario_system_prompt(&Language::Japanese);
+        assert!(ja_prompt.contains("マーケティング戦略家"));
+        assert!(ja_prompt.contains("JSONのみで応答"));
+
+        let en_prompt = get_scenario_system_prompt(&Language::English);
+        assert!(en_prompt.contains("marketing strategist"));
+        assert!(en_prompt.contains("valid JSON only"));
+    }
+
+    #[test]
+    fn test_get_content_generation_system_prompt() {
+        let ja_prompt = get_content_generation_system_prompt(&Language::Japanese);
+        assert!(ja_prompt.contains("コピーライター"));
+        assert!(ja_prompt.contains("マークダウン形式"));
+
+        let en_prompt = get_content_generation_system_prompt(&Language::English);
+        assert!(en_prompt.contains("copywriter"));
+        assert!(en_prompt.contains("markdown format"));
+    }
+
+    #[test]
+    fn test_generate_scenario_user_prompt() {
+        let ja_prompt = generate_scenario_user_prompt(
+            "SaaS",
+            "スタートアップ",
+            "リード獲得",
+            Some("B2B向け"),
+            &Language::Japanese,
+        );
+        assert!(ja_prompt.contains("業界: SaaS"));
+        assert!(ja_prompt.contains("ターゲット層: スタートアップ"));
+        assert!(ja_prompt.contains("目標: リード獲得"));
+        assert!(ja_prompt.contains("追加の文脈: B2B向け"));
+
+        let en_prompt = generate_scenario_user_prompt(
+            "SaaS",
+            "Startups",
+            "Lead Generation",
+            Some("B2B focused"),
+            &Language::English,
+        );
+        assert!(en_prompt.contains("Industry: SaaS"));
+        assert!(en_prompt.contains("Target Audience: Startups"));
+        assert!(en_prompt.contains("Goal: Lead Generation"));
+        assert!(en_prompt.contains("Additional Context: B2B focused"));
+    }
+
+    #[test]
+    fn test_generate_subject_optimization_prompt() {
+        let ja_prompt = generate_subject_optimization_prompt(
+            "新製品のお知らせ",
+            "エンジニア",
+            &Language::Japanese,
+        );
+        assert!(ja_prompt.contains("エンジニア向けに最適化"));
+        assert!(ja_prompt.contains("元の件名: 新製品のお知らせ"));
+
+        let en_prompt = generate_subject_optimization_prompt(
+            "New Product Announcement",
+            "Engineers",
+            &Language::English,
+        );
+        assert!(en_prompt.contains("optimize the following subject line for Engineers"));
+        assert!(en_prompt.contains("Original subject: New Product Announcement"));
+    }
+}

--- a/backend/src/ai/models/tests.rs
+++ b/backend/src/ai/models/tests.rs
@@ -1,0 +1,50 @@
+#[cfg(test)]
+mod tests {
+    use super::super::*;
+
+    #[test]
+    fn test_language_from_code() {
+        assert_eq!(Language::from_code("ja"), Some(Language::Japanese));
+        assert_eq!(Language::from_code("JA"), Some(Language::Japanese));
+        assert_eq!(Language::from_code("japanese"), Some(Language::Japanese));
+        assert_eq!(Language::from_code("en"), Some(Language::English));
+        assert_eq!(Language::from_code("EN"), Some(Language::English));
+        assert_eq!(Language::from_code("english"), Some(Language::English));
+        assert_eq!(Language::from_code("invalid"), None);
+    }
+
+    #[test]
+    fn test_language_to_code() {
+        assert_eq!(Language::Japanese.to_code(), "ja");
+        assert_eq!(Language::English.to_code(), "en");
+    }
+
+    #[test]
+    fn test_language_default() {
+        assert_eq!(Language::default(), Language::Japanese);
+    }
+
+    #[test]
+    fn test_language_serialization() {
+        use serde_json;
+
+        let ja = Language::Japanese;
+        let json = serde_json::to_string(&ja).unwrap();
+        assert_eq!(json, r#""ja""#);
+
+        let en = Language::English;
+        let json = serde_json::to_string(&en).unwrap();
+        assert_eq!(json, r#""en""#);
+    }
+
+    #[test]
+    fn test_language_deserialization() {
+        use serde_json;
+
+        let ja: Language = serde_json::from_str(r#""ja""#).unwrap();
+        assert_eq!(ja, Language::Japanese);
+
+        let en: Language = serde_json::from_str(r#""en""#).unwrap();
+        assert_eq!(en, Language::English);
+    }
+}

--- a/backend/src/ai/services/content_generator.rs
+++ b/backend/src/ai/services/content_generator.rs
@@ -109,28 +109,59 @@ impl ContentGeneratorService {
 
     /// コンテンツプロンプトを構築
     fn build_content_prompt(&self, request: &GenerateContentRequest) -> String {
-        let mut prompt = format!("{}を作成してください。\n\n", request.content_type);
+        let language = request.context.language.unwrap_or_default();
 
-        if let Some(industry) = &request.context.industry {
-            prompt.push_str(&format!("業界: {}\n", industry));
+        match language {
+            crate::ai::models::Language::Japanese => {
+                let mut prompt = format!("{}を作成してください。\n\n", request.content_type);
+
+                if let Some(industry) = &request.context.industry {
+                    prompt.push_str(&format!("業界: {}\n", industry));
+                }
+
+                if let Some(audience) = &request.context.target_audience {
+                    prompt.push_str(&format!("ターゲット層: {}\n", audience));
+                }
+
+                if let Some(tone) = &request.context.tone {
+                    prompt.push_str(&format!("トーン: {:?}\n", tone));
+                }
+
+                if let Some(existing) = &request.context.existing_content {
+                    prompt.push_str(&format!(
+                        "\n既存のコンテンツを改善してください:\n{}\n",
+                        existing
+                    ));
+                }
+
+                prompt.push_str("\n重要：すべての出力を日本語で生成してください。");
+                prompt
+            }
+            crate::ai::models::Language::English => {
+                let mut prompt = format!("Create a {} content.\n\n", request.content_type);
+
+                if let Some(industry) = &request.context.industry {
+                    prompt.push_str(&format!("Industry: {}\n", industry));
+                }
+
+                if let Some(audience) = &request.context.target_audience {
+                    prompt.push_str(&format!("Target Audience: {}\n", audience));
+                }
+
+                if let Some(tone) = &request.context.tone {
+                    prompt.push_str(&format!("Tone: {:?}\n", tone));
+                }
+
+                if let Some(existing) = &request.context.existing_content {
+                    prompt.push_str(&format!(
+                        "\nImprove the following existing content:\n{}\n",
+                        existing
+                    ));
+                }
+
+                prompt
+            }
         }
-
-        if let Some(audience) = &request.context.target_audience {
-            prompt.push_str(&format!("ターゲット層: {}\n", audience));
-        }
-
-        if let Some(tone) = &request.context.tone {
-            prompt.push_str(&format!("トーン: {:?}\n", tone));
-        }
-
-        if let Some(existing) = &request.context.existing_content {
-            prompt.push_str(&format!(
-                "\n既存のコンテンツを改善してください:\n{}\n",
-                existing
-            ));
-        }
-
-        prompt
     }
 
     /// 変数を抽出

--- a/backend/src/ai/services/scenario_builder.rs
+++ b/backend/src/ai/services/scenario_builder.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::ai::models::prompts::{generate_scenario_user_prompt, get_scenario_system_prompt};
 use crate::ai::models::{
-    GenerateScenarioRequest, GenerateScenarioResponse, GeneratedForm, GeneratedFormField,
+    GenerateScenarioRequest, GenerateScenarioResponse, GeneratedForm, GeneratedFormField, Language,
 };
 use crate::ai::{AIProvider, ChatMessage, MessageRole};
 
@@ -62,7 +62,7 @@ impl ScenarioBuilderService {
             })?;
 
         // 検証とデフォルト値の設定
-        let validated_response = self.validate_and_enhance_response(response)?;
+        let validated_response = self.validate_and_enhance_response(response, &language)?;
 
         Ok(validated_response)
     }
@@ -71,6 +71,7 @@ impl ScenarioBuilderService {
     fn validate_and_enhance_response(
         &self,
         mut response: GenerateScenarioResponse,
+        language: &Language,
     ) -> Result<GenerateScenarioResponse> {
         // シーケンスの検証
         if response.sequence.steps.is_empty() {
@@ -85,7 +86,7 @@ impl ScenarioBuilderService {
         // フォームの検証と拡張
         if response.forms.is_empty() {
             // デフォルトのリードキャプチャフォームを追加
-            response.forms.push(self.create_default_lead_form());
+            response.forms.push(self.create_default_lead_form(language));
         }
 
         // ステップの遅延時間を正規化
@@ -102,33 +103,62 @@ impl ScenarioBuilderService {
     }
 
     /// デフォルトのリードキャプチャフォームを作成
-    fn create_default_lead_form(&self) -> GeneratedForm {
-        GeneratedForm {
-            name: "リードキャプチャフォーム".to_string(),
-            description: "メールアドレスと基本情報を収集するフォーム".to_string(),
-            fields: vec![
-                GeneratedFormField {
-                    field_type: "email".to_string(),
-                    name: "email".to_string(),
-                    label: "メールアドレス".to_string(),
-                    required: true,
-                    options: None,
-                },
-                GeneratedFormField {
-                    field_type: "text".to_string(),
-                    name: "name".to_string(),
-                    label: "お名前".to_string(),
-                    required: true,
-                    options: None,
-                },
-                GeneratedFormField {
-                    field_type: "text".to_string(),
-                    name: "company".to_string(),
-                    label: "会社名".to_string(),
-                    required: false,
-                    options: None,
-                },
-            ],
+    fn create_default_lead_form(&self, language: &Language) -> GeneratedForm {
+        match language {
+            Language::Japanese => GeneratedForm {
+                name: "リードキャプチャフォーム".to_string(),
+                description: "メールアドレスと基本情報を収集するフォーム".to_string(),
+                fields: vec![
+                    GeneratedFormField {
+                        field_type: "email".to_string(),
+                        name: "email".to_string(),
+                        label: "メールアドレス".to_string(),
+                        required: true,
+                        options: None,
+                    },
+                    GeneratedFormField {
+                        field_type: "text".to_string(),
+                        name: "name".to_string(),
+                        label: "お名前".to_string(),
+                        required: true,
+                        options: None,
+                    },
+                    GeneratedFormField {
+                        field_type: "text".to_string(),
+                        name: "company".to_string(),
+                        label: "会社名".to_string(),
+                        required: false,
+                        options: None,
+                    },
+                ],
+            },
+            Language::English => GeneratedForm {
+                name: "Lead Capture Form".to_string(),
+                description: "Form to collect email address and basic information".to_string(),
+                fields: vec![
+                    GeneratedFormField {
+                        field_type: "email".to_string(),
+                        name: "email".to_string(),
+                        label: "Email Address".to_string(),
+                        required: true,
+                        options: None,
+                    },
+                    GeneratedFormField {
+                        field_type: "text".to_string(),
+                        name: "name".to_string(),
+                        label: "Name".to_string(),
+                        required: true,
+                        options: None,
+                    },
+                    GeneratedFormField {
+                        field_type: "text".to_string(),
+                        name: "company".to_string(),
+                        label: "Company".to_string(),
+                        required: false,
+                        options: None,
+                    },
+                ],
+            },
         }
     }
 }
@@ -152,9 +182,10 @@ mod tests {
         let provider = create_ai_provider(config).unwrap();
         let service = ScenarioBuilderService::new(provider);
 
-        let form = service.create_default_lead_form();
+        let form = service.create_default_lead_form(&Language::Japanese);
         assert_eq!(form.fields.len(), 3);
         assert_eq!(form.fields[0].field_type, "email");
         assert!(form.fields[0].required);
+        assert_eq!(form.fields[0].label, "メールアドレス");
     }
 }

--- a/backend/src/tests/api/ai_test.rs
+++ b/backend/src/tests/api/ai_test.rs
@@ -1,6 +1,6 @@
 use crate::ai::models::{
     ai_responses::{ContentContext, GenerateContentRequest, OptimizeSubjectRequest},
-    GenerateScenarioRequest,
+    GenerateScenarioRequest, Language,
 };
 
 #[cfg(test)]
@@ -18,6 +18,7 @@ mod tests {
             target_audience: "スタートアップ企業".to_string(),
             goal: "無料トライアルから有料プランへの転換".to_string(),
             additional_context: Some("B2B向けのプロジェクト管理ツール".to_string()),
+            language: Some(Language::Japanese),
         };
 
         assert_eq!(request.industry, "SaaS");
@@ -33,7 +34,7 @@ mod tests {
                 industry: Some("SaaS".to_string()),
                 target_audience: Some("エンジニア".to_string()),
                 tone: None,
-                language: Some("ja".to_string()),
+                language: Some(Language::Japanese),
                 existing_content: None,
             },
             options: None,
@@ -41,7 +42,7 @@ mod tests {
 
         assert_eq!(request.content_type, "email");
         assert_eq!(request.context.industry, Some("SaaS".to_string()));
-        assert_eq!(request.context.language, Some("ja".to_string()));
+        assert_eq!(request.context.language, Some(Language::Japanese));
     }
 
     #[test]
@@ -51,6 +52,7 @@ mod tests {
             target_audience: "既存ユーザー".to_string(),
             campaign_goal: Some("エンゲージメント向上".to_string()),
             variations_count: Some(5),
+            language: Some(Language::Japanese),
         };
 
         assert_eq!(request.original_subject, "新機能のお知らせ");

--- a/frontend/src/lib/types/ai.ts
+++ b/frontend/src/lib/types/ai.ts
@@ -1,5 +1,8 @@
 // AI機能の型定義
 
+// サポートされる言語
+export type Language = "ja" | "en";
+
 // コンテンツタイプ
 export type ContentType =
   | "email_template"
@@ -22,6 +25,7 @@ export interface GenerateScenarioRequest {
   target_audience: string;
   goal: string;
   additional_context?: string;
+  language?: Language;
 }
 
 // シナリオ生成レスポンス
@@ -87,7 +91,7 @@ export interface ContentContext {
   industry?: string;
   target_audience?: string;
   tone?: ContentTone;
-  language?: string;
+  language?: Language;
   existing_content?: string;
 }
 
@@ -120,6 +124,7 @@ export interface OptimizeSubjectRequest {
   target_audience: string;
   campaign_goal?: string;
   variations_count?: number;
+  language?: Language;
 }
 
 // 件名最適化レスポンス

--- a/frontend/src/routes/ai/content/new/+page.svelte
+++ b/frontend/src/routes/ai/content/new/+page.svelte
@@ -11,6 +11,7 @@
     GenerateContentRequest,
     GenerateContentResponse,
     ContentTone,
+    Language,
   } from "$lib/types/ai";
 
   let isAuthenticated = false;
@@ -23,7 +24,7 @@
   let industry = "";
   let targetAudience = "";
   let tone: ContentTone = "professional";
-  let language = "ja";
+  let language: Language = "ja";
   let existingContent = "";
   let includeVariations = true;
   let includePersonalization = true;
@@ -243,6 +244,27 @@
               placeholder="既存のメールやコンテンツを貼り付けると、そのスタイルを参考に生成します"
               class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
             />
+          </div>
+
+          <!-- 出力言語 -->
+          <div>
+            <label
+              for="language"
+              class="block text-sm font-medium text-gray-700 mb-2"
+            >
+              出力言語
+            </label>
+            <select
+              id="language"
+              bind:value={language}
+              class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+            >
+              <option value="ja">日本語</option>
+              <option value="en">英語</option>
+            </select>
+            <p class="mt-1 text-sm text-gray-500">
+              生成されるコンテンツの言語を選択してください
+            </p>
           </div>
 
           <!-- オプション -->

--- a/frontend/src/routes/ai/scenarios/new/+page.svelte
+++ b/frontend/src/routes/ai/scenarios/new/+page.svelte
@@ -6,6 +6,7 @@
   import type {
     GenerateScenarioRequest,
     GenerateScenarioResponse,
+    Language,
   } from "$lib/types/ai";
 
   let isAuthenticated = false;
@@ -19,6 +20,7 @@
     target_audience: "",
     goal: "",
     additional_context: "",
+    language: "ja" as Language,
   };
 
   // 生成結果
@@ -91,6 +93,7 @@
       target_audience: "",
       goal: "",
       additional_context: "",
+      language: "ja" as Language,
     };
   }
 
@@ -224,6 +227,27 @@
               placeholder="特別な要件や制約があれば記入してください"
               class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
             />
+          </div>
+
+          <!-- 出力言語 -->
+          <div>
+            <label
+              for="language"
+              class="block text-sm font-medium text-gray-700 mb-2"
+            >
+              出力言語
+            </label>
+            <select
+              id="language"
+              bind:value={formData.language}
+              class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+            >
+              <option value="ja">日本語</option>
+              <option value="en">英語</option>
+            </select>
+            <p class="mt-1 text-sm text-gray-500">
+              生成されるシナリオの言語を選択してください
+            </p>
           </div>
 
           <!-- エラーメッセージ -->

--- a/frontend/src/routes/ai/subject-optimizer/+page.svelte
+++ b/frontend/src/routes/ai/subject-optimizer/+page.svelte
@@ -6,6 +6,7 @@
   import type {
     OptimizeSubjectRequest,
     OptimizeSubjectResponse,
+    Language,
   } from "$lib/types/ai";
 
   let isAuthenticated = false;
@@ -18,6 +19,7 @@
   let targetAudience = "";
   let campaignGoal = "";
   let variationsCount = 5;
+  let language: Language = "ja";
 
   // 最適化結果
   let optimizationResult: OptimizeSubjectResponse | null = null;
@@ -55,6 +57,7 @@
       target_audience: targetAudience,
       campaign_goal: campaignGoal || undefined,
       variations_count: variationsCount,
+      language,
     };
 
     try {
@@ -220,6 +223,27 @@
               <option value={7}>7つ</option>
               <option value={10}>10つ</option>
             </select>
+          </div>
+
+          <!-- 出力言語 -->
+          <div>
+            <label
+              for="language"
+              class="block text-sm font-medium text-gray-700 mb-2"
+            >
+              出力言語
+            </label>
+            <select
+              id="language"
+              bind:value={language}
+              class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+            >
+              <option value="ja">日本語</option>
+              <option value="en">英語</option>
+            </select>
+            <p class="mt-1 text-sm text-gray-500">
+              最適化された件名の言語を選択してください
+            </p>
           </div>
 
           <!-- エラーメッセージ -->


### PR DESCRIPTION
## Summary
- AI機能に日本語/英語の言語選択機能を追加
- バックエンドで多言語プロンプトテンプレートを実装
- フロントエンドの全AI機能画面に言語選択UIを追加

## Changes
### Backend
- `Language`列挙型を追加（日本語/英語）
- AI関連モデルに言語フィールドを追加
- 言語別のプロンプトテンプレートを実装
- サービス層で選択された言語に応じたプロンプトを使用

### Frontend
- `Language`型定義を追加
- 全AI機能画面（シナリオ生成、コンテンツ生成、件名最適化）に言語選択ドロップダウンを追加
- デフォルト言語を日本語に設定

## Test plan
- [x] バックエンドのテストが全て通過
- [x] フロントエンドのテストが全て通過
- [ ] AI機能で日本語選択時に日本語で結果が生成されることを確認
- [ ] AI機能で英語選択時に英語で結果が生成されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)