### PR TITLE
feat: AWS環境でのStripe決済機能を完全統合

### DIFF
--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -96,6 +96,8 @@ const ecsClusterStack = new ECSClusterStack(app, `MarkMail-${environmentName}-EC
   environmentName: config.environmentName,
   vpc: networkStack.vpc,
   dbSecret: databaseStack.dbSecret,
+  aiSecret: databaseStack.aiSecret,
+  stripeSecret: databaseStack.stripeSecret,
   description: `MarkMail ECS Cluster Stack for ${environmentName} environment`,
 });
 ecsClusterStack.addDependency(networkStack);
@@ -142,6 +144,7 @@ const ecsServiceStack = new ECSServiceStack(app, `MarkMail-${environmentName}-EC
   database: databaseStack.database,
   dbSecret: databaseStack.dbSecret,
   aiSecret: databaseStack.aiSecret,
+  stripeSecret: databaseStack.stripeSecret,
   cacheCluster: databaseStack.cacheCluster,
   loadBalancer: albStack.loadBalancer,
   httpsListener: albStack.httpsListener,

--- a/infrastructure/lib/stacks/database-stack.ts
+++ b/infrastructure/lib/stacks/database-stack.ts
@@ -16,6 +16,7 @@ export class DatabaseStack extends cdk.Stack {
   public readonly dbSecret: cdk.aws_secretsmanager.Secret;
   public readonly cacheCluster: cdk.aws_elasticache.CfnCacheCluster;
   public readonly aiSecret: cdk.aws_secretsmanager.Secret;
+  public readonly stripeSecret: cdk.aws_secretsmanager.Secret;
 
   constructor(scope: Construct, id: string, props: DatabaseStackProps) {
     super(scope, id, props);
@@ -56,6 +57,17 @@ export class DatabaseStack extends cdk.Stack {
       },
     });
 
+    // Stripe関連のシークレット
+    this.stripeSecret = new cdk.aws_secretsmanager.Secret(this, 'StripeSecret', {
+      secretName: `markmail-${environmentName}-stripe-secret`,
+      description: 'Stripe API keys and webhook secrets',
+      secretObjectValue: {
+        STRIPE_SECRET_KEY: cdk.SecretValue.unsafePlainText('your-stripe-secret-key-here'),
+        STRIPE_PUBLISHABLE_KEY: cdk.SecretValue.unsafePlainText('your-stripe-publishable-key-here'),
+        STRIPE_WEBHOOK_SECRET: cdk.SecretValue.unsafePlainText('your-stripe-webhook-secret-here'),
+      },
+    });
+
     // Export values for cross-stack references
     new cdk.CfnOutput(this, 'DatabaseEndpoint', {
       value: this.database.dbInstanceEndpointAddress,
@@ -80,6 +92,11 @@ export class DatabaseStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'AISecretArn', {
       value: this.aiSecret.secretArn,
       exportName: `${this.stackName}-AISecretArn`,
+    });
+
+    new cdk.CfnOutput(this, 'StripeSecretArn', {
+      value: this.stripeSecret.secretArn,
+      exportName: `${this.stackName}-StripeSecretArn`,
     });
 
     // Stack tags

--- a/infrastructure/lib/stacks/ecs-service-stack.ts
+++ b/infrastructure/lib/stacks/ecs-service-stack.ts
@@ -23,6 +23,7 @@ export interface ECSServiceStackProps extends cdk.StackProps {
   database: rds.DatabaseInstance;
   dbSecret: secretsmanager.Secret;
   aiSecret?: secretsmanager.Secret;
+  stripeSecret?: secretsmanager.Secret;
   cacheCluster: elasticache.CfnCacheCluster;
   loadBalancer: elbv2.ApplicationLoadBalancer;
   httpsListener?: elbv2.ApplicationListener;
@@ -58,6 +59,7 @@ export class ECSServiceStack extends cdk.Stack {
       database,
       dbSecret,
       aiSecret,
+      stripeSecret,
       cacheCluster,
       httpsListener,
       httpListener,
@@ -98,6 +100,17 @@ export class ECSServiceStack extends cdk.Stack {
           AI_PROVIDER: ecs.Secret.fromSecretsManager(aiSecret, 'AI_PROVIDER'),
           OPENAI_MODEL: ecs.Secret.fromSecretsManager(aiSecret, 'OPENAI_MODEL'),
           ANTHROPIC_MODEL: ecs.Secret.fromSecretsManager(aiSecret, 'ANTHROPIC_MODEL'),
+        }),
+        ...(stripeSecret && {
+          STRIPE_SECRET_KEY: ecs.Secret.fromSecretsManager(stripeSecret, 'STRIPE_SECRET_KEY'),
+          STRIPE_PUBLISHABLE_KEY: ecs.Secret.fromSecretsManager(
+            stripeSecret,
+            'STRIPE_PUBLISHABLE_KEY'
+          ),
+          STRIPE_WEBHOOK_SECRET: ecs.Secret.fromSecretsManager(
+            stripeSecret,
+            'STRIPE_WEBHOOK_SECRET'
+          ),
         }),
       },
       logging: ecs.LogDrivers.awsLogs({


### PR DESCRIPTION
## 📋 概要

AWS環境でのStripe決済機能を完全に統合し、セキュアで本番環境に近い実装を実現しました。

## 🚀 主な変更内容

### インフラストラクチャの改善
- **Stripeシークレット管理**: AWS Secrets Managerを使用した安全な認証情報管理
- **IAM権限の修正**: ECSタスク実行ロールにAI・Stripeシークレットへのアクセス権限を追加
- **ECS統合**: バックエンドコンテナにStripe環境変数を設定
- **GitHub接続の柔軟化**: 既存接続の利用とCDK作成の両方に対応

### セキュリティ強化
- プライベートリポジトリ対応でAWS Connector for GitHub設定
- Route 53ドメイン（`dev.markmail.engineers-hub.ltd`）を使用したSSL通信
- Stripe CLIによるWebhookエンドポイントの安全な作成

### 実装された機能
- AWS環境でのStripe決済フローの完全動作
- 踏み台ホスト経由でのRDSデータベース更新
- SSL付きドメインでのWebhook受信

## 🔧 技術的な詳細

### 変更されたファイル
- `infrastructure/lib/stacks/database-stack.ts`: Stripeシークレット管理の追加
- `infrastructure/lib/stacks/ecs-cluster-stack.ts`: IAM権限の修正
- `infrastructure/lib/stacks/ecs-service-stack.ts`: ECSタスクへの環境変数設定
- `infrastructure/lib/stacks/cicd-stack.ts`: GitHub接続の柔軟な管理
- `infrastructure/bin/infrastructure.ts`: スタック間の依存関係修正
- `docs/stripe-payment-setup.md`: AWS環境での設定手順を詳細に追記

### 解決した問題
1. **ECSタスクでのStripeシークレット取得エラー**: IAM権限不足が原因
2. **プライベートリポジトリでのCI/CDパイプライン問題**: AWS Connector for GitHub設定で解決
3. **Webhookエンドポイントの設定**: Stripe CLIによる自動化

## 🧪 テスト状況

- ✅ バックエンドテスト: 93 passed, 0 failed, 5 ignored
- ✅ フロントエンドテスト: 59 passed, 0 failed, 9 skipped
- ✅ AWS環境での実際の決済テスト完了

## 📚 ドキュメント更新

`docs/stripe-payment-setup.md`に以下を追加：
- 踏み台ホスト経由でのRDS操作方法の詳細手順
- Stripe CLIを使用したWebhookエンドポイント作成方法
- Route 53ドメインを使用したSSL通信設定
- トラブルシューティング手順の大幅拡充
- AWS環境での検証手順

## 🎯 動作確認

AWS環境（https://dev.markmail.engineers-hub.ltd）で以下の機能が正常動作することを確認：
- Stripe決済フローの完全な動作
- Webhookイベントの正常な受信と処理
- サブスクリプションプランの更新

🤖 Generated with [Claude Code](https://claude.ai/code)