### PR TITLE
feat: シーケンス詳細画面でテンプレート情報を表示

### DIFF
--- a/backend/src/api/sequences.rs
+++ b/backend/src/api/sequences.rs
@@ -191,8 +191,9 @@ pub async fn get_sequence_with_steps(
     State(state): State<AppState>,
     Extension(user): Extension<AuthUser>,
     Path(sequence_id): Path<Uuid>,
-) -> Result<Json<crate::models::sequence::SequenceWithSteps>, (StatusCode, Json<Value>)> {
-    match db::get_sequence_with_steps(&state.db, sequence_id).await {
+) -> Result<Json<crate::models::sequence::SequenceWithStepsAndTemplates>, (StatusCode, Json<Value>)>
+{
+    match db::get_sequence_with_steps_and_templates(&state.db, sequence_id).await {
         Ok(Some(sequence_data)) => {
             if sequence_data.sequence.user_id == user.user_id {
                 Ok(Json(sequence_data))

--- a/backend/src/models/sequence.rs
+++ b/backend/src/models/sequence.rs
@@ -102,6 +102,20 @@ pub struct SequenceWithSteps {
     pub steps: Vec<SequenceStep>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SequenceStepWithTemplate {
+    #[serde(flatten)]
+    pub step: SequenceStep,
+    pub template: Option<crate::models::template::Template>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SequenceWithStepsAndTemplates {
+    #[serde(flatten)]
+    pub sequence: Sequence,
+    pub steps: Vec<SequenceStepWithTemplate>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct SequenceStepLog {
     pub id: Uuid,

--- a/backend/src/models/template.rs
+++ b/backend/src/models/template.rs
@@ -5,7 +5,7 @@ use sqlx::FromRow;
 use uuid::Uuid;
 use validator::Validate;
 
-#[derive(Debug, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct Template {
     pub id: Uuid,
     pub user_id: Uuid,

--- a/backend/src/tests/api/sequences.rs
+++ b/backend/src/tests/api/sequences.rs
@@ -438,7 +438,7 @@ async fn test_sequence_with_steps() {
     let sequence_with_steps = get_with_steps_result.unwrap().0;
     assert_eq!(sequence_with_steps.sequence.name, "ステップ付きシーケンス");
     assert_eq!(sequence_with_steps.steps.len(), 1);
-    assert_eq!(sequence_with_steps.steps[0].name, "ウェルカムメール");
+    assert_eq!(sequence_with_steps.steps[0].step.name, "ウェルカムメール");
 
     // クリーンアップ
     sqlx::query!(

--- a/frontend/src/lib/services/sequenceService.ts
+++ b/frontend/src/lib/services/sequenceService.ts
@@ -4,6 +4,7 @@ import type {
   Sequence,
   SequenceStep,
   SequenceWithSteps,
+  SequenceWithStepsAndTemplates,
   CreateSequenceRequest,
   UpdateSequenceRequest,
   CreateSequenceStepRequest,
@@ -58,8 +59,8 @@ class SequenceService {
     return this.request<Sequence[]>("/sequences");
   }
 
-  async getSequence(id: string): Promise<SequenceWithSteps> {
-    return this.request<SequenceWithSteps>(`/sequences/${id}/full`);
+  async getSequence(id: string): Promise<SequenceWithStepsAndTemplates> {
+    return this.request<SequenceWithStepsAndTemplates>(`/sequences/${id}/full`);
   }
 
   async createSequence(data: CreateSequenceRequest): Promise<Sequence> {

--- a/frontend/src/lib/types/sequence.ts
+++ b/frontend/src/lib/types/sequence.ts
@@ -109,13 +109,26 @@ export interface SequenceWithSteps extends Sequence {
   steps: SequenceStep[];
 }
 
-export interface SequenceStepWithTemplate extends SequenceStep {
+// バックエンドの#[serde(flatten)]により、Sequenceのフィールドがトップレベルに展開される
+export type SequenceWithStepsAndTemplates = Sequence & {
+  steps: SequenceStepWithTemplate[];
+};
+
+// バックエンドの#[serde(flatten)]により、SequenceStepのフィールドがトップレベルに展開される
+export type SequenceStepWithTemplate = SequenceStep & {
   template?: {
     id: string;
+    user_id: string;
     name: string;
-    subject: string;
+    subject_template: string;
+    markdown_content: string;
+    html_content?: string;
+    variables: any;
+    is_public: boolean;
+    created_at: string;
+    updated_at: string;
   };
-}
+};
 
 // ビジュアルエディタ用の型
 

--- a/frontend/src/routes/sequences/[id]/+page.svelte
+++ b/frontend/src/routes/sequences/[id]/+page.svelte
@@ -3,12 +3,9 @@
   import { page } from "$app/stores";
   import { goto } from "$app/navigation";
   import { sequenceService } from "$lib/services/sequenceService";
-  import type {
-    SequenceWithSteps,
-    SequenceStepWithTemplate,
-  } from "$lib/types/sequence";
+  import type { SequenceWithStepsAndTemplates } from "$lib/types/sequence";
 
-  let sequence: SequenceWithSteps | null = null;
+  let sequence: SequenceWithStepsAndTemplates | null = null;
   let loading = true;
   let error = "";
 
@@ -199,7 +196,32 @@
                     </h3>
                   </div>
 
-                  {#if step.step_type === "email" && step.template_id}
+                  {#if step.step_type === "email" && step.template}
+                    <div class="text-sm text-gray-600 space-y-2">
+                      <div>
+                        <span class="font-medium">テンプレート:</span>
+                        {step.template.name}
+                      </div>
+                      <div>
+                        <span class="font-medium">件名:</span>
+                        {step.template.subject_template}
+                      </div>
+                      {#if step.template.markdown_content}
+                        <div
+                          class="mt-2 p-3 bg-white rounded border border-gray-200"
+                        >
+                          <div class="text-xs text-gray-500 mb-1">
+                            プレビュー:
+                          </div>
+                          <div
+                            class="text-sm prose prose-sm max-w-none line-clamp-3"
+                          >
+                            {step.template.markdown_content}
+                          </div>
+                        </div>
+                      {/if}
+                    </div>
+                  {:else if step.step_type === "email" && step.template_id}
                     <div class="text-sm text-gray-600">
                       <p>テンプレート: #{step.template_id}</p>
                     </div>


### PR DESCRIPTION
## 概要
シーケンスの詳細画面で、各ステップのテンプレートIDだけでなく、テンプレートの詳細情報（名前、件名、内容のプレビュー）を表示するように改善しました。

## 変更内容
- バックエンドの`get_sequence_with_steps_and_templates`関数を修正
  - シーケンス所有者のユーザーIDを使用してテンプレートを取得するように変更
  - これにより、プライベートテンプレートも正しく取得できるようになりました
- フロントエンドの型定義を更新
  - `#[serde(flatten)]`の構造に合わせて型定義を修正
- `Template`モデルに`Clone`トレイトを追加
- デバッグ用のconsole.logを削除

## スクリーンショット
修正前：テンプレートIDのみ表示（例：#dfbe3aba-7ef5-43f5-8db3-e119ec91a405）
修正後：テンプレート名、件名、内容のプレビューを表示

## テスト
- バックエンドの全テストが通過 ✅
- フロントエンドのテストが通過 ✅
- 手動でシーケンス詳細画面を確認し、テンプレート情報が正しく表示されることを確認 ✅

🤖 Generated with [Claude Code](https://claude.ai/code)