### PR TITLE
feat: シーケンス詳細画面からテンプレート編集画面への遷移機能を追加

### DIFF
--- a/frontend/src/routes/sequences/[id]/+page.svelte
+++ b/frontend/src/routes/sequences/[id]/+page.svelte
@@ -198,9 +198,30 @@
 
                   {#if step.step_type === "email" && step.template}
                     <div class="text-sm text-gray-600 space-y-2">
-                      <div>
-                        <span class="font-medium">テンプレート:</span>
-                        {step.template.name}
+                      <div class="flex items-center justify-between">
+                        <div>
+                          <span class="font-medium">テンプレート:</span>
+                          {step.template.name}
+                        </div>
+                        <a
+                          href="/templates/{step.template.id}/edit"
+                          class="text-blue-600 hover:text-blue-800 text-xs font-medium flex items-center"
+                        >
+                          <svg
+                            class="w-4 h-4 mr-1"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                          >
+                            <path
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                            />
+                          </svg>
+                          編集
+                        </a>
                       </div>
                       <div>
                         <span class="font-medium">件名:</span>


### PR DESCRIPTION
## Summary
- シーケンスステップのテンプレート表示部分に編集リンクを追加
- テンプレート名の横に編集アイコン付きのリンクを配置して、クリックでテンプレート編集画面へ遷移可能に
- CLAUDE.mdに開発サーバー制御とテスト実行に関する重要事項を追加

## Test plan
- [ ] フロントエンドサーバーを起動
- [ ] シーケンス詳細画面を開く
- [ ] テンプレート名の横にある「編集」リンクをクリック
- [ ] テンプレート編集画面へ正しく遷移することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)