### PR TITLE
feat: シーケンス削除時に関連するフォームとテンプレートも削除する機能を追加

### DIFF
--- a/frontend/src/routes/sequences/+page.svelte
+++ b/frontend/src/routes/sequences/+page.svelte
@@ -51,7 +51,15 @@
   }
 
   async function handleDelete(id: number) {
-    if (!confirm("このシーケンスを削除してもよろしいですか？")) {
+    const confirmMessage =
+      "このシーケンスを削除すると、関連するフォームとテンプレートも削除されます。\n\n" +
+      "削除されるもの：\n" +
+      "• シーケンス本体\n" +
+      "• 紐づけられたフォーム（存在する場合）\n" +
+      "• シーケンスで使用しているメールテンプレート\n\n" +
+      "この操作は取り消すことができません。本当に削除してもよろしいですか？";
+
+    if (!confirm(confirmMessage)) {
       return;
     }
 


### PR DESCRIPTION
## Summary
- シーケンス削除時に関連するフォームとテンプレートも自動削除する機能を実装
- 参照されていないテンプレートのみを削除するスマートな削除処理
- ユーザーに削除される関連エンティティについて明確に警告表示

## Changes
### Backend
- `delete_sequence`関数を拡張し、関連エンティティの削除処理を追加
  - フォーム送信トリガーの場合は関連フォームを削除
  - 他から参照されていないテンプレートを自動削除
- 新しいヘルパー関数を追加
  - `is_template_referenced`: テンプレートの参照チェック
  - `delete_unreferenced_template`: 参照されていないテンプレートの削除

### Frontend
- シーケンス削除確認ダイアログを改善
  - 削除される関連エンティティについて明確に警告
  - ユーザーが削除の影響を理解できるように詳細表示

## Test plan
- [x] バックエンドテスト: 全93テストが成功
- [x] フロントエンドテスト: 全58テストが成功
- [x] 実際の動作確認
  - 手動トリガーのシーケンス削除でフォームが残ることを確認
  - テンプレートが他から参照されていない場合のみ削除されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)