### PR TITLE
fix: OpenAI APIのタイムアウトを180秒に延長

### DIFF
--- a/backend/src/api/ai.rs
+++ b/backend/src/api/ai.rs
@@ -80,7 +80,7 @@ async fn get_ai_provider(
         api_key,
         model,
         max_retries: 3,
-        timeout_seconds: 60,
+        timeout_seconds: 180,
     };
 
     create_ai_provider(config).map_err(|e| {


### PR DESCRIPTION
## Summary
- OpenAI APIのタイムアウト設定を60秒から180秒に延長
- マーケティングシナリオ生成など複雑なAIタスクでタイムアウトエラーが発生していた問題を修正

## Test plan
- [x] AI機能の「AIマーケティングシナリオ生成」でタイムアウトエラーが発生しなくなることを確認
- [x] 他のAI機能（コンテンツ生成、件名最適化）も正常に動作することを確認
- [x] バックエンドのテストが全て通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)