### PR TITLE
chore: add cipher/MCP directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ build/
 
 # Serena
 .serena/
+
+# Cipher/MCP
+memAgent/
+.mcp.json
+data/


### PR DESCRIPTION
## Summary
- Add memAgent/, .mcp.json, and data/ directories to .gitignore
- Prevent tracking of cipher and MCP configuration files and data

## Changes
- Added Cipher/MCP section to .gitignore with three new entries

## Test plan
- [x] Verified .gitignore syntax is valid
- [x] Confirmed directories are properly ignored by git

🤖 Generated with [Claude Code](https://claude.ai/code)